### PR TITLE
Bump doris-android to version 2.4.3 

### DIFF
--- a/d2g/build.gradle
+++ b/d2g/build.gradle
@@ -33,23 +33,8 @@ dependencies {
     implementation 'com.google.android.material:material:1.8.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
-
-    // If dorisVersion >= 2.2.13
     implementation "com.github.DiceTechnology.doris-android:doris:$dorisVersion"
     implementation "com.github.DiceTechnology.doris-android:doris-ui:$dorisVersion"
-
-    // If dorisVersion < 2.2.13
-    /*
-    implementation ("com.github.DiceTechnology.doris-android:doris:$dorisVersion") {
-        exclude group: 'com.github.DiceTechnology', module: 'dice-shield-android'
-    }
-    implementation ("com.github.DiceTechnology.doris-android:doris-ui:$dorisVersion") {
-        exclude group: 'com.github.DiceTechnology', module: 'dice-shield-android'
-    }
-    implementation("com.github.DiceTechnology:dice-shield-android:$diceShieldVersion") {
-        exclude group: "com.google.android.exoplayer", module: "exoplayer"
-    }
-    */
 
     // RxJava
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'

--- a/d2g/src/main/java/com/dice/doris/example/PlayerActivity.java
+++ b/d2g/src/main/java/com/dice/doris/example/PlayerActivity.java
@@ -40,7 +40,7 @@ public class PlayerActivity extends AppCompatActivity {
                 .setUri(videoItem.getUrl());
 
         Source source = new SourceBuilder()
-                .setMediaItem(mediaItemBuilder.build())
+                .setMediaItemBuilder(mediaItemBuilder)
                 .setId(videoItem.getId())
                 .setShouldPlayOffline(true)
                 .setDrmParams(new ActionToken(Utils.DRM_SCHEME, videoItem.getOfflineLicense()))

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,4 +1,3 @@
 ext{
-    dorisVersion = '2.2.13'
-    diceShieldVersion = '0.18.2' // Only needed if dorisVersion < 2.2.13
+    dorisVersion = '2.4.3'
 }


### PR DESCRIPTION
Bump doris-android to version 2.4.3 which allows to delete downloaded assets while being offline.